### PR TITLE
Add data checkpoint

### DIFF
--- a/configs/summit_setup.yml
+++ b/configs/summit_setup.yml
@@ -8,8 +8,6 @@
   #"vocab-file": "/home/lfsm/code/gpt-neox/data/gpt2-vocab.json",
   #"merge-file": "/home/lfsm/code/gpt-neox/data/gpt2-merges.txt",
 
-  "tokenizer_type": "HFGPT2Tokenizer",
-  
   "save": "/gpfs/alpine/scratch/lfsm/csc499/checkpoints",
   "load": "/gpfs/alpine/scratch/lfsm/csc499/checkpoints",
   # separate load path for pretrained clip, same with 'load' in this case

--- a/megatron/data/data_utils.py
+++ b/megatron/data/data_utils.py
@@ -494,7 +494,7 @@ def compile_helper():
 
         sys.exit(1)
 
-def build_web_train_valid_test_data_iterators(neox_args):
+def build_web_train_valid_test_data_loaders(neox_args):
     """XXX"""
     (train_dataloader, valid_dataloader, test_dataloader) = (None, None, None)
 
@@ -514,10 +514,8 @@ def build_web_train_valid_test_data_iterators(neox_args):
         assert (
             neox_args.train_data_paths
                 ),f'in webdataset format, require --train_data_path'
-        train_data = get_wds_data(neox_args,is_train=True) 
-        valid_data = get_wds_data(neox_args,is_train=False) 
-        train_dataloader = train_data.dataloader
-        valid_dataloader = valid_data.dataloader
+        train_dataloader = get_wds_data(neox_args,is_train=True) 
+        valid_dataloader = get_wds_data(neox_args,is_train=False) 
         #[TODO] No test data set up yet 
         
         # Flags to know if we need to do training/validation/testing.
@@ -542,22 +540,4 @@ def build_web_train_valid_test_data_iterators(neox_args):
     neox_args.do_train = flags[0].item()
     neox_args.do_valid = flags[1].item()
     neox_args.do_test = flags[2].item()
-    
-    # [TODO] may need to setup the start_iter and manage shard epoch here
-        # Build iterators.
-    if train_dataloader is not None:
-        train_data_iterator = iter(train_dataloader)
-    else:
-        train_data_iterator = None
-
-    if valid_dataloader is not None:
-        valid_data_iterator = iter(valid_dataloader)
-    else:
-        valid_data_iterator = None
-
-    if test_dataloader is not None:
-        test_data_iterator = iter(test_dataloader)
-    else:
-        test_data_iterator = None
- 
-    return train_data_iterator, valid_data_iterator, test_data_iterator
+    return train_dataloader, valid_dataloader, test_dataloader 

--- a/megatron/data/webdataset.py
+++ b/megatron/data/webdataset.py
@@ -225,7 +225,6 @@ class SimpleShardList2(IterableDataset):
 
         print(f'start at {epoch} sub epoch with number {self.num_sub_epochs} with {len(urls)} shards and total shards{len(self.urls.copy())}')
         for url in urls:
-            print(f'get url {url} now from {os.environ["RANK"]}')
             yield dict(url=url)
 
 def image_text_dict_collation_fn(samples):
@@ -253,8 +252,8 @@ from itertools import islice
 def my_split_by_node(src):
     rank, world_size = get_data_parallel_info()
     if world_size > 1:
-        import pdb;pdb.set_trace()
         for s in islice(src, rank, None, world_size):
+            print(f'get url {s} now from {rank}')
             yield s
     else:
         for s in src:
@@ -343,7 +342,8 @@ def get_wds_data(args, is_train, floor=False):
     if is_train:
         if not resampled:
             num_shards = len(expand_urls(input_shards)[0])
-            assert num_shards/num_sub_epochs >= num_workers * world_size, 'number of shards of subset must be >= total workers'
+            print(f'number of shards of subset{num_shards/num_sub_epochs} is >= total workers {num_workers * world_size}')
+            assert num_shards/num_sub_epochs >= num_workers * world_size, f'number of shards of subset{num_shards/num_sub_epochs} must be >= total workers{num_workers * world_size}'
         dataset = dataset.with_epoch(num_worker_batches)  # each worker is iterating over this
 
     dataloader = wds.WebLoader(

--- a/megatron/model/image_prefix.py
+++ b/megatron/model/image_prefix.py
@@ -84,7 +84,7 @@ def clip_encoder(
         encoder = open_clip.create_model(
             name, 
             device=device, 
-            precision="fp16" if "cuda" in str(device) else "fp32", 
+            precision= "fp32", 
             pretrained=pretrained,
             cache_dir=cache_path
         ).visual
@@ -92,8 +92,7 @@ def clip_encoder(
         encoder = open_clip.create_model(
             name, 
             device=device, 
-            precision="fp16" if "cuda" in str(device) else "fp32", 
-            # pretrained=pretrained,
+            precision= "fp32", 
             cache_dir=cache_path
         ).visual
          
@@ -155,7 +154,8 @@ def get_image_encoder(
 ENCODER_SEQ_LENS = {
     "clip_resnet": 49,
     "clip_resnet_large": 144,
-    "openclip-H": 257
+    "openclip-H": 257,
+    "openclip-B32": 257,
 }
 
 ENCODER_OUT_DIMS = {
@@ -164,6 +164,7 @@ ENCODER_OUT_DIMS = {
     "clip_resnet": 2560,
     "clip_resnet_large": 3072,
     "openclip-H": 1024,
+    "openclip-B32": 512,
 }
 
 
@@ -194,7 +195,7 @@ class ImagePrefix(nn.Module):
         # get image encoder backbone
         self.enc = get_image_encoder(
             config.encoder_name,
-            # device=self.device,
+            device=self.device,
             pretrained=config.pretrained_img_encoder,
             cache_path = config.load_clip
         )
@@ -220,7 +221,6 @@ class ImagePrefix(nn.Module):
 
         # pass through image encoder
         logits = self.enc(x)
-
         # remove trailing dimensions of size 1 + pass through linear
         if logits.ndim == 4:
             logits = rearrange(logits, "b d 1 1 -> b d")

--- a/megatron/model/image_prefix.py
+++ b/megatron/model/image_prefix.py
@@ -183,12 +183,10 @@ class ImagePrefix(nn.Module):
         self,
         config,
         out_dim: int = 2048,
-        device=None,
+        device='cpu',
     ):
         super().__init__()
-        self.device = device or torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu"
-        )
+        self.device = device
         self.config = config
         self.encoder_type = config.encoder_name
 

--- a/megatron/model/word_embeddings.py
+++ b/megatron/model/word_embeddings.py
@@ -171,7 +171,7 @@ class EmbeddingPipe(Embedding):
         
         self.image_prefix = ImagePrefix(
             config = neox_args,
-            out_dim=neox_args.hidden_size,
+            out_dim = neox_args.hidden_size,
         )
 
     @property

--- a/megatron/neox_arguments/arguments.py
+++ b/megatron/neox_arguments/arguments.py
@@ -173,21 +173,6 @@ class NeoXArgs(*BASE_CLASSES):
         else:
             sub_epoch_num = 0
         self.shared_epoch = SharedEpoch(epoch=sub_epoch_num)
-        # compute meta data for dataloader
-        self.global_batch_size = self.batch_size * self.world_size 
-        num_batches = round_fn(self.train_num_samples / self.global_batch_size)
-        num_workers = max(1, self.num_workers)
-        num_worker_batches = round_fn(num_batches / num_workers)  # per dataloader worker
-        self.num_batches = num_worker_batches * num_workers
-        self.train_one_epoch_iters = round_fn(self.num_batches / self.gradient_accumulation_steps)
-        self.num_subepochs_per_epoch = round_fn(self.train_one_epoch_iters / self.checkpoint_factor)
-        
-        assert (
-            self.checkpoint_scale == 'linear'
-                ), f'webdataset only works with linear checkpoint saving way'
-        assert (
-            self.num_subepochs_per_epoch != 0
-            ), f'num_subepochs_per_epoch == 0, please decrease checkpoint_factor or increase train_num_samples'
 
     @classmethod
     def from_ymls(cls, paths_to_yml_files: List[str], overwrite_values: Dict = None):

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -842,12 +842,10 @@ def train(
     overflow_monitor = OverflowMonitor(optimizer)
     while iteration < neox_args.train_iters:
         # rebuild data-iter when updating sub shared-epoch
-        if  train_data_iterator is not None and iteration in neox_args.save_iters:
+        if not neox_args.dataset_resampled and train_data_iterator is not None and iteration in neox_args.save_iters:
             sub_epoch_num = int(iteration / neox_args.checkpoint_factor)
             print_rank_0(f'reset shared epoch value to {sub_epoch_num}')
-            neox_args.shared_epoch.set_value(sub_epoch_num)
-            if train_dataloader is not None:
-                train_data_iterator = iter(train_dataloader)            
+            neox_args.shared_epoch.set_value(sub_epoch_num)      
         
         loss_dict, skipped_iter = train_step(
             neox_args=neox_args,

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -842,7 +842,7 @@ def train(
     overflow_monitor = OverflowMonitor(optimizer)
     while iteration < neox_args.train_iters:
         # rebuild data-iter when updating sub shared-epoch
-        if neox_args.num_subepochs_per_epoch and train_data_iterator is not None and iteration in neox_args.save_iters:
+        if  train_data_iterator is not None and iteration in neox_args.save_iters:
             sub_epoch_num = int(iteration / neox_args.checkpoint_factor)
             print_rank_0(f'reset shared epoch value to {sub_epoch_num}')
             neox_args.shared_epoch.set_value(sub_epoch_num)

--- a/train.py
+++ b/train.py
@@ -23,5 +23,6 @@ if __name__ == "__main__":
     neox_args = NeoXArgs.consume_neox_args()
     neox_args.configure_distributed_args()
     neox_args.build_tokenizer()  # tokenizer needs to be build in training in order to set the padding vocab
+    neox_args.bulid_shared_epoch() # build the shared epoch to manage dataloader
     neox_args.initialize_tensorboard_writer()  # is initialized if tensorboard directory is defined
     pretrain(neox_args=neox_args)


### PR DESCRIPTION
Add data checkpoint feature within one epoch, also add support for openclipb32.
We split the total train shards into small sub-shards set, we train one sub-shards set for one interval between checkpoints.
Therefore we must hold certain constrains:
- number of shards of sub-shards sets must larger than total workers(numboer of workers times world size of data parallel).
- checkpoint save way must be linear for spliting the shards evenly.   

To regenerate data iterator everytime we switch to a new sub-shard sets, I feed the dataloader to our train function and rebuild the data iterator upon it everytime we hit the save iteration.